### PR TITLE
feat: Add APIs for loyalty, receipts, and reviews

### DIFF
--- a/app/api/loyalty/customer_loyaltyp.py
+++ b/app/api/loyalty/customer_loyaltyp.py
@@ -1,0 +1,279 @@
+from flask import Blueprint, jsonify, request, current_app
+from sqlalchemy import select, func
+from app.extensions import db
+from ...models import (
+    Customers, Salon, LoyaltyAccount, LoyaltyProgram, Appointment,
+     LoyaltyTransaction, Promos
+)
+from datetime import datetime, timedelta
+import uuid
+
+loyalty_bp = Blueprint("loyalty", __name__, url_prefix="/api/loyalty")
+
+
+
+def get_customer_from_id(customer_id):
+    """Helper to find a customer by their main ID (not auth_user.id)."""
+    return db.session.get(Customers, customer_id)
+
+def get_loyalty_account(customer_id, salon_id):
+    """Helper to get a specific loyalty account."""
+    return db.session.scalars(
+        select(LoyaltyAccount)
+        .where(LoyaltyAccount.user_id == customer_id)
+        .where(LoyaltyAccount.salon_id == salon_id)
+    ).first()
+
+
+
+@loyalty_bp.route("/customers/<int:customer_id>/dashboard", methods=['GET'])
+def get_loyalty_dashboard(customer_id):
+    """
+    --- Endpoint 1: Customer Loyalty Dashboard (Aggregate) ---
+    
+    Powers the top-level summary cards in your UI (e.g., "Lifetime Points", 
+    "Active Programs", "Total Visits").
+    """
+    try:
+        customer = get_customer_from_id(customer_id)
+        if not customer:
+            return jsonify({"status": "error", "message": "Customer not found"}), 404
+
+        # 1. Get all loyalty accounts for this customer
+        accounts = db.session.scalars(
+            select(LoyaltyAccount).where(LoyaltyAccount.user_id == customer_id)
+        ).all()
+        
+        # 2. Calculate stats
+        active_programs_count = len(accounts)
+        current_total_points = sum(acc.points for acc in accounts)
+
+   
+        total_visits = db.session.scalar(
+            select(func.count(Appointment.id))
+            .where(Appointment.customer_id == customer_id)
+            .where(Appointment.status == 'COMPLETED') 
+        )
+        
+     
+        
+        response = {
+            "current_total_points": current_total_points, 
+            "active_programs_count": active_programs_count,
+            "total_visits_all_time": total_visits or 0
+        }
+        return jsonify(response)
+        
+    except Exception as e:
+        current_app.logger.error(f"Failed to get loyalty dashboard for customer {customer_id}: {e}")
+        return jsonify({"status": "error", "message": "Failed to get dashboard", "details": str(e)}), 500
+
+
+@loyalty_bp.route("/customers/<int:customer_id>/programs", methods=['GET'])
+def get_customer_loyalty_programs(customer_id):
+    """
+    --- Endpoint 2: Customer's Loyalty Programs List ---
+    
+    Powers the main list in your UI (e.g., the "Jade Boutique" card).
+    """
+    try:
+        customer = get_customer_from_id(customer_id)
+        if not customer:
+            return jsonify({"status": "error", "message": "Customer not found"}), 404
+            
+        stmt = (
+            select(LoyaltyAccount, Salon, LoyaltyProgram)
+            .join(Salon, LoyaltyAccount.salon_id == Salon.id)
+            .join(LoyaltyProgram, LoyaltyProgram.salon_id == Salon.id)
+            .where(LoyaltyAccount.user_id == customer_id)
+            .where(LoyaltyProgram.active == True) 
+        )
+        
+        results = db.session.execute(stmt).all()
+        
+        response_list = []
+        for acc, salon, program in results:
+            
+            visits_at_salon = db.session.scalar(
+                select(func.count(Appointment.id))
+                .where(Appointment.customer_id == customer_id)
+                .where(Appointment.salon_id == salon.id)
+                .where(Appointment.status == 'COMPLETED') 
+            )
+
+            points_for_reward = getattr(program, 'points_for_reward', 1000) 
+            points_away = max(0, points_for_reward - acc.points)
+            
+            response_list.append({
+                "salon_id": salon.id,
+                "salon_name": salon.name,
+                "current_points": acc.points,
+                "total_visits_at_salon": visits_at_salon or 0,
+                "program_details": {
+                    "description": getattr(program, 'reward_description', f"{points_for_reward} points for reward"),
+                    "points_per_dollar": float(getattr(program, 'points_per_dollar', 1)), 
+                },
+                "next_reward_progress": {
+                    "points_to_next_reward": points_for_reward,
+                    "points_away": points_away
+                }
+            })
+            
+        return jsonify(response_list)
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to get loyalty programs for customer {customer_id}: {e}")
+        return jsonify({"status": "error", "message": "Failed to get programs", "details": str(e)}), 500
+
+
+@loyalty_bp.route("/customers/<int:customer_id>/programs/<int:salon_id>/activity", methods=['GET'])
+def get_loyalty_activity(customer_id, salon_id):
+    """
+    --- Endpoint 3: Salon-Specific Recent Activity ---
+    
+    This queries the LoyaltyTransaction table 
+
+    """
+    try:
+        account = get_loyalty_account(customer_id, salon_id)
+        if not account:
+            return jsonify({"status": "error", "message": "Loyalty account not found for this customer and salon"}), 404
+        
+        stmt = (
+            select(LoyaltyTransaction)
+            .where(LoyaltyTransaction.loyalty_account_id == account.id)
+            .order_by(LoyaltyTransaction.created_at.desc())
+            .limit(20) 
+        )
+        transactions = db.session.scalars(stmt).all()
+
+        activity_list = []
+        for txn in transactions:
+           
+            activity_list.append({
+                "activity_id": f"txn_{txn.id}",
+                "date": txn.created_at.isoformat(),
+                "description": txn.reason, 
+                "points_change": txn.points_change 
+            })
+
+        return jsonify(activity_list)
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to get loyalty activity for cust {customer_id}, salon {salon_id}: {e}")
+        return jsonify({"status": "error", "message": "Failed to get activity", "details": str(e)}), 500
+
+
+@loyalty_bp.route("/customers/<int:customer_id>/programs/<int:salon_id>/rewards", methods=['GET'])
+def get_available_rewards(customer_id, salon_id):
+    """
+    --- Endpoint 4: Get Available Rewards ---
+    
+    Fetches loyalty rewards a customer can redeem with their points
+    for the "Reward" tab.
+    """
+    try:
+        account = get_loyalty_account(customer_id, salon_id)
+        if not account:
+            return jsonify({"status": "error", "message": "Loyalty account not found"}), 404
+        
+        program = db.session.scalar(
+            select(LoyaltyProgram).where(LoyaltyProgram.salon_id == salon_id)
+        )
+        if not program or not program.active:
+            return jsonify({"status": "error", "message": "No active loyalty program for this salon"}), 404
+
+    
+        
+        points_for_reward = getattr(program, 'points_for_reward', 1000)
+        can_redeem = account.points >= points_for_reward
+
+        reward_list = [
+            {
+                "reward_id": f"prog_{program.id}_main_reward", 
+                "description": getattr(program, 'reward_description', f"{program.reward_value}% off"),
+                "points_cost": points_for_reward,
+                "is_redeemable": can_redeem,
+                "reward_type": str(program.reward_type), 
+                "reward_value": float(program.reward_value) 
+            }
+           
+        ]
+        
+        return jsonify(reward_list)
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to get available rewards for cust {customer_id}, salon {salon_id}: {e}")
+        return jsonify({"status": "error", "message": "Failed to get rewards", "details": str(e)}), 500
+
+
+@loyalty_bp.route("/customers/<int:customer_id>/programs/<int:salon_id>/redeem", methods=['POST'])
+def redeem_loyalty_reward(customer_id, salon_id):
+    """
+    --- Endpoint 5: Redeem Loyalty Reward ---
+    
+    The action of spending points to get a reward.
+    This deducts points, logs the transaction, and creates a
+    one-time promo code.
+    """
+    try:
+        data = request.json
+        reward_id = data.get('reward_id')
+        if not reward_id:
+            return jsonify({"status": "error", "message": "reward_id is required"}), 400
+
+        account = get_loyalty_account(customer_id, salon_id)
+        if not account:
+            return jsonify({"status": "error", "message": "Loyalty account not found"}), 404
+            
+        
+        program = db.session.scalar(select(LoyaltyProgram).where(LoyaltyProgram.salon_id == salon_id))
+        if not program:
+             return jsonify({"status": "error", "message": "Loyalty program not found"}), 404
+       
+        points_cost = getattr(program, 'points_for_reward', 1000)
+        
+        
+        if account.points < points_cost:
+            return jsonify({"status": "error", "message": "Not enough points"}), 400
+            
+        account.points -= points_cost
+        db.session.add(account)
+        
+        new_txn = LoyaltyTransaction(
+            loyalty_account_id=account.id,
+            points_change=-points_cost,
+            reason="REDEEM_REWARD",
+           
+        )
+        db.session.add(new_txn)
+        
+        promo_code = f"LOYALTY-{str(uuid.uuid4())[:8].upper()}"
+        expires = datetime.utcnow() + timedelta(days=30) 
+
+        new_promo = Promos(
+            code=promo_code,
+            type=program.reward_type,
+            value=program.reward_value,
+            is_active=True,
+            expires_at=expires,
+            description=f"Loyalty Reward for Customer {customer_id} from Salon {salon_id}"
+        )
+        db.session.add(new_promo)
+        
+        db.session.commit()
+        
+        return jsonify({
+            "status": "success",
+            "message": "Reward redeemed successfully!",
+            "data": {
+                "new_points_balance": account.points,
+                "promo_code_generated": new_promo.code,
+                "expires_at": new_promo.expires_at.isoformat()
+            }
+        }), 201
+
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Failed to redeem reward for cust {customer_id}, salon {salon_id}: {e}")
+        return jsonify({"status": "error", "message": "Failed to redeem reward", "details": str(e)}), 500

--- a/app/api/payments/receipts.py
+++ b/app/api/payments/receipts.py
@@ -1,1 +1,130 @@
 #Invoices, refunds, tracking
+from flask import Blueprint, jsonify
+from ...extensions import db
+from ...models import (
+    Payment, Salon, Order, Customers, 
+    OrderItem,  Booking, Appointment
+)
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload, selectinload
+
+# Create a new blueprint for payments
+receipts_bp = Blueprint("payment", __name__, url_prefix="/api/receipts")
+
+# -------------------------------------------------------------------------
+# GET /api/payment/salon/<int:salon_id>/transactions
+# Purpose: Get all transactions for a specific salon, formatted for
+#          the SalonOwner Payment page.
+# -------------------------------------------------------------------------
+@receipts_bp.route("/salon/<int:salon_id>/transactions", methods=["GET"])
+def get_salon_transactions(salon_id):
+    """
+    Returns all transactions for a given salon id, including
+    customer info, item details, and payment status.
+    """
+    try:
+        salon = db.session.get(Salon, salon_id)
+        if not salon:
+            return jsonify({
+                "status": "error",
+                "message": f"Salon with id {salon_id} not found"
+            }), 404
+
+
+        query = (
+                select(Payment)
+                .join(Payment.order)
+                .where(Order.salon_id == salon_id)
+                .options(
+                    joinedload(Payment.pay_method),
+             
+                    joinedload(Payment.order).options(
+                        
+                        joinedload(Order.customer).joinedload(Customers.user),
+                        
+                        selectinload(Order.order_item).options(
+                            
+                            joinedload(OrderItem.service),
+                            
+                            joinedload(OrderItem.product),
+                            
+                            selectinload(OrderItem.booking).options(
+                                
+                                joinedload(Booking.appointment)
+                                    .joinedload(Appointment.employee)
+                            )
+                        )
+                    )
+                )
+                .order_by(Payment.created_at.desc()) 
+            )
+
+        payments = db.session.scalars(query).all()
+
+        transactions_list = []
+        for payment in payments:
+            order = payment.order
+            
+            if not order or not order.customer or not order.customer.user:
+                continue
+
+            customer = order.customer
+            auth_user = customer.user
+            
+            items_summary = []
+            stylist_name = None
+
+            for item in order.order_item:
+                if item.service:
+                    items_summary.append(item.service.name)
+                    
+                    if item.booking:
+                        if item.booking[0].appointment:
+                            appointment = item.booking[0].appointment
+                            if appointment.employee:
+                                emp = appointment.employee
+                                stylist_name = f"{emp.first_name} {emp.last_name}"
+
+                elif item.product:
+                    items_summary.append(item.product.name)
+
+        
+            status = ""
+            if payment.status == 'FAILED':
+                status = 'Failed'
+            elif payment.status == 'PENDING':
+                status = 'Pending'
+            elif payment.status == 'SUCCESSFUL':
+             
+                status = order.status 
+            
+            transactions_list.append({
+                "transaction_id": payment.transaction_id,
+                "payment_id": payment.id,
+                "order_id": order.id,
+                "date": payment.created_at.isoformat(),
+                "customer_name": f"{customer.first_name} {customer.last_name}",
+                "customer_email": auth_user.email,
+                "items": items_summary,
+                "stylist": stylist_name or "N/A",
+                "amount": float(payment.amount),
+                "payment_method": payment.pay_method.brand if payment.pay_method else "Unknown",
+                "status": status.capitalize() if status else "Unknown",
+                "refund_reason": order.refund_reason 
+            })
+
+        return jsonify({
+            "status": "success",
+            "salon_id": salon_id,
+            "transaction_count": len(transactions_list),
+            "transactions": transactions_list
+        }), 200
+
+    except Exception as e:
+        db.session.rollback()
+        
+        return jsonify({
+            "status": "error",
+            "message": "Internal server error",
+            "details": str(e)
+        }), 500

--- a/app/api/salons/reviews.py
+++ b/app/api/salons/reviews.py
@@ -1,1 +1,0 @@
-#Reviews, review images

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
-from typing import List, Optional
+﻿from typing import List, Optional
 
 from sqlalchemy import BigInteger, CHAR, Column, DECIMAL, Date, DateTime, Enum, ForeignKeyConstraint, Index, Integer, JSON, String, TIMESTAMP, Table, Text, Time, VARBINARY, text
-from sqlalchemy.dialects.mysql import TINYINT
+from sqlalchemy.dialects.mysql import TINYINT, VARCHAR
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column, relationship
 from sqlalchemy.orm.base import Mapped
 
@@ -70,14 +70,6 @@ class Types(Base):
     name = mapped_column(String(100), nullable=False)
 
     salon: Mapped['Salon'] = relationship('Salon', secondary='salon_type_assignments', back_populates='type')
-
-
-class Users(Base):
-    __tablename__ = 'users'
-
-    id = mapped_column(Integer, primary_key=True)
-    created_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
-    updated_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
 
 
 class Admins(Base):
@@ -199,7 +191,7 @@ class PayMethod(Base):
     updated_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
     brand = mapped_column(String(50))
     last4 = mapped_column(CHAR(4))
-    expiration = mapped_column(Date)
+    Expiration = mapped_column(Date)
 
     user: Mapped['Customers'] = relationship('Customers', back_populates='pay_method')
     payment: Mapped[List['Payment']] = relationship('Payment', uselist=True, back_populates='pay_method')
@@ -284,6 +276,7 @@ class Order(Base):
     total_amnt = mapped_column(DECIMAL(10, 2))
     promo_id = mapped_column(Integer)
     submitted_at = mapped_column(DateTime)
+    refund_reason = mapped_column(Text)
 
     customer: Mapped[Optional['Customers']] = relationship('Customers', back_populates='_order')
     promo: Mapped[Optional['Promos']] = relationship('Promos', back_populates='_order')
@@ -291,6 +284,7 @@ class Order(Base):
     order_item: Mapped[List['OrderItem']] = relationship('OrderItem', uselist=True, back_populates='order')
     payment: Mapped[List['Payment']] = relationship('Payment', uselist=True, back_populates='order')
     review_token: Mapped[List['ReviewToken']] = relationship('ReviewToken', uselist=True, back_populates='order')
+    loyalty_transaction: Mapped[List['LoyaltyTransaction']] = relationship('LoyaltyTransaction', uselist=True, back_populates='order')
 
 
 class CancelPolicy(Base):
@@ -356,6 +350,7 @@ class LoyaltyAccount(Base):
 
     salon: Mapped['Salon'] = relationship('Salon', back_populates='loyalty_account')
     user: Mapped['Customers'] = relationship('Customers', back_populates='loyalty_account')
+    loyalty_transaction: Mapped[List['LoyaltyTransaction']] = relationship('LoyaltyTransaction', uselist=True, back_populates='loyalty_account')
 
 
 class LoyaltyProgram(Base):
@@ -368,11 +363,15 @@ class LoyaltyProgram(Base):
     id = mapped_column(Integer, primary_key=True)
     salon_id = mapped_column(Integer, nullable=False)
     active = mapped_column(TINYINT(1), nullable=False, server_default=text("'0'"))
-    visits_for_reward = mapped_column(Integer, nullable=False, server_default=text("'0'"))
+    program_type = mapped_column(Enum('POINTS', 'VISITS'), nullable=False, server_default=text("'POINTS'"))
     created_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
     updated_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
+    points_per_dollar = mapped_column(DECIMAL(10, 2), server_default=text("'1.00'"))
+    visits_for_reward = mapped_column(Integer)
     reward_type = mapped_column(Enum('PERCENT', 'FIXED_AMOUNT', 'FREE_ITEM'))
     reward_value = mapped_column(DECIMAL(10, 2))
+    reward_description = mapped_column(String(255), server_default=text("'Reward'"))
+    points_for_reward = mapped_column(Integer, server_default=text("'1000'"))
 
     salon: Mapped['Salon'] = relationship('Salon', back_populates='loyalty_program')
 
@@ -556,14 +555,13 @@ class Appointment(Base):
     price_at_book = mapped_column(DECIMAL(10, 2))
     notes = mapped_column(Text)
 
-
     customer: Mapped[Optional['Customers']] = relationship('Customers', back_populates='appointment')
     employee: Mapped[Optional['Employees']] = relationship('Employees', back_populates='appointment')
     salon: Mapped[Optional['Salon']] = relationship('Salon', back_populates='appointment')
     service: Mapped[Optional['Service']] = relationship('Service', back_populates='appointment')
+    appointment_image: Mapped[List['AppointmentImage']] = relationship('AppointmentImage', uselist=True, back_populates='appointment')
     booking: Mapped[List['Booking']] = relationship('Booking', uselist=True, back_populates='appointment')
-    #-- Barek Stripling 11/5/25 - Add appointment_image table to store images for carts --> appointments
-    images: Mapped[List['AppointmentImage']] = relationship('AppointmentImage', back_populates='appointment')
+    loyalty_transaction: Mapped[List['LoyaltyTransaction']] = relationship('LoyaltyTransaction', uselist=True, back_populates='appointment')
 
 
 class CartItem(Base):
@@ -586,8 +584,6 @@ class CartItem(Base):
     price = mapped_column(DECIMAL(10, 2))
     added_at = mapped_column(TIMESTAMP, server_default=text('CURRENT_TIMESTAMP'))
     updated_at = mapped_column(TIMESTAMP, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
-
-    # NEW COLUMNS ADDED "Barek Stripling 11/5/25 - Added columns to cart_item and appointments table":
     start_at = mapped_column(DateTime)
     end_at = mapped_column(DateTime)
     notes = mapped_column(Text)
@@ -595,9 +591,7 @@ class CartItem(Base):
     cart: Mapped['Cart'] = relationship('Cart', back_populates='cart_item')
     product: Mapped[Optional['Product']] = relationship('Product', back_populates='cart_item')
     service: Mapped[Optional['Service']] = relationship('Service', back_populates='cart_item')
-
-    #Barek Stripling 11/5/25 - Add appointment_image table to store images for carts --> appointments
-    images: Mapped[List['AppointmentImage']] = relationship('AppointmentImage', back_populates='cart_item')
+    appointment_image: Mapped[List['AppointmentImage']] = relationship('AppointmentImage', uselist=True, back_populates='cart_item')
 
 
 class EmpAvail(Base):
@@ -777,6 +771,26 @@ class TimeBlock(Base):
     salon: Mapped[Optional['Salon']] = relationship('Salon', back_populates='time_block')
 
 
+class AppointmentImage(Base):
+    __tablename__ = 'appointment_image'
+    __table_args__ = (
+        ForeignKeyConstraint(['appointment_id'], ['appointment.id'], ondelete='CASCADE', name='appointment_image_appointment_FK'),
+        ForeignKeyConstraint(['cart_item_id'], ['cart_item.id'], ondelete='CASCADE', name='appointment_image_cart_item_FK'),
+        Index('appointment_image_appointment_FK', 'appointment_id'),
+        Index('appointment_image_cart_item_FK', 'cart_item_id')
+    )
+
+    id = mapped_column(Integer, primary_key=True)
+    url = mapped_column(VARCHAR(512), nullable=False)
+    cart_item_id = mapped_column(Integer)
+    appointment_id = mapped_column(Integer)
+    created_at = mapped_column(DateTime, server_default=text('CURRENT_TIMESTAMP'))
+    updated_at = mapped_column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
+
+    appointment: Mapped[Optional['Appointment']] = relationship('Appointment', back_populates='appointment_image')
+    cart_item: Mapped[Optional['CartItem']] = relationship('CartItem', back_populates='appointment_image')
+
+
 class Booking(Base):
     __tablename__ = 'booking'
     __table_args__ = (
@@ -815,23 +829,26 @@ class Invoice(Base):
 
     payment: Mapped[Optional['Payment']] = relationship('Payment', back_populates='invoice')
 
-# Barek Stripling 11/5/25 - Add appointment_image table to store images for carts --> appointments
-class AppointmentImage(Base):
-    __tablename__ = 'appointment_image'
+
+class LoyaltyTransaction(Base):
+    __tablename__ = 'loyalty_transaction'
     __table_args__ = (
-        ForeignKeyConstraint(['cart_item_id'], ['cart_item.id'], ondelete='CASCADE', name='fk_appt_img_cart_item'),
-        ForeignKeyConstraint(['appointment_id'], ['appointment.id'], ondelete='CASCADE', name='fk_appt_img_appointment'),
-        Index('idx_cart_item', 'cart_item_id'),
-        Index('idx_appointment', 'appointment_id')
+        ForeignKeyConstraint(['appointment_id'], ['appointment.id'], ondelete='SET NULL', name='loyalty_transaction_ibfk_3'),
+        ForeignKeyConstraint(['loyalty_account_id'], ['loyalty_account.id'], ondelete='CASCADE', name='loyalty_transaction_ibfk_1'),
+        ForeignKeyConstraint(['order_id'], ['_order.id'], ondelete='SET NULL', name='loyalty_transaction_ibfk_2'),
+        Index('idx_appointment', 'appointment_id'),
+        Index('idx_loyalty_account', 'loyalty_account_id'),
+        Index('idx_order', 'order_id')
     )
 
     id = mapped_column(Integer, primary_key=True)
-    url = mapped_column(String(512), nullable=False)
-    cart_item_id = mapped_column(Integer)
+    loyalty_account_id = mapped_column(Integer, nullable=False)
+    points_change = mapped_column(Integer, nullable=False, comment='Positive for earned, negative for spent')
+    created_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
+    reason = mapped_column(String(50), comment='e.g., PURCHASE, REDEEM_REWARD, MANUAL_ADJUST')
+    order_id = mapped_column(Integer)
     appointment_id = mapped_column(Integer)
-    created_at = mapped_column(DateTime, server_default=text('CURRENT_TIMESTAMP'))
-    updated_at = mapped_column(DateTime, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
 
-    # Relationships
-    cart_item: Mapped[Optional['CartItem']] = relationship('CartItem', back_populates='images')
-    appointment: Mapped[Optional['Appointment']] = relationship('Appointment', back_populates='images')
+    appointment: Mapped[Optional['Appointment']] = relationship('Appointment', back_populates='loyalty_transaction')
+    loyalty_account: Mapped['LoyaltyAccount'] = relationship('LoyaltyAccount', back_populates='loyalty_transaction')
+    order: Mapped[Optional['Order']] = relationship('Order', back_populates='loyalty_transaction')

--- a/app/routes/reviews.py
+++ b/app/routes/reviews.py
@@ -1,10 +1,119 @@
 from flask import Blueprint, jsonify, request, current_app
 from app.extensions import db
-from ..models import Review, ReviewImage 
+from ..models import Review, ReviewImage ,Customers, Salon
 from app.utils.s3_utils import upload_file_to_s3 
 import uuid
-
+from sqlalchemy.exc import IntegrityError
 reviews_bp = Blueprint("reviews", __name__, url_prefix="/api/reviews")
+
+# -------------------------------------------------------------------------
+# POST /api/reviews/post
+# Purpose: Create a new review with an optional image upload.
+# -------------------------------------------------------------------------
+@reviews_bp.route("/postreview", methods=["POST"])
+def post_new_review():
+    """
+    Handles creating a new review.
+    Expects multipart/form-data with:
+    - customer_id (int)
+    - salon_id (int)
+    - rating (int)
+    - comment (string)
+    - picture (file, optional)
+    """
+    try:
+
+        customer_id = request.form.get("customer_id", type=int)
+        salon_id = request.form.get("salon_id", type=int)
+        rating = request.form.get("rating", type=int)
+        comment = request.form.get("comment")
+        
+        image_file = request.files.get("picture") 
+
+        if not all([customer_id, salon_id, rating]):
+            return jsonify({
+                "status": "error",
+                "message": "Missing required fields: customer_id, salon_id, rating"
+            }), 400
+
+        if not 1 <= rating <= 5:
+             return jsonify({
+                "status": "error",
+                "message": "Rating must be an integer between 1 and 5"
+            }), 400
+
+        customer = db.session.get(Customers, customer_id)
+        if not customer:
+            return jsonify({"status": "error", "message": "Customer not found"}), 404
+
+        salon = db.session.get(Salon, salon_id)
+        if not salon:
+            return jsonify({"status": "error", "message": "Salon not found"}), 404
+
+        new_review = Review(
+            customers_id=customer_id,
+            salon_id=salon_id,
+            rating=rating,
+            comment=comment
+        )
+        db.session.add(new_review)
+        
+        db.session.flush() 
+
+        image_url = None
+        new_image_id = None
+
+        if image_file:
+            bucket_name = current_app.config.get("S3_BUCKET_NAME")
+            if not bucket_name:
+                current_app.logger.error("S3_BUCKET_NAME is not configured")
+                db.session.rollback() 
+                return jsonify({"error": "Server configuration error"}), 500
+
+            unique_name = f"reviews/{new_review.id}/{uuid.uuid4()}_{image_file.filename}"
+            
+            image_url = upload_file_to_s3(image_file, unique_name, bucket_name)
+            
+            if not image_url:
+                db.session.rollback() 
+                return jsonify({"error": "File upload failed"}), 500
+
+            new_image = ReviewImage(
+                review_id=new_review.id,
+                url=image_url
+            )
+            db.session.add(new_image)
+            db.session.flush()
+            new_image_id = new_image.id
+
+        db.session.commit()
+
+        return jsonify({
+            "status": "success",
+            "message": "Review posted successfully",
+            "review": {
+                "id": new_review.id,
+                "customer_id": new_review.customers_id,
+                "salon_id": new_review.salon_id,
+                "rating": new_review.rating,
+                "comment": new_review.comment,
+                "created_at": new_review.created_at.isoformat(),
+                "image": {
+                    "id": new_image_id,
+                    "url": image_url
+                } if image_url else None
+            }
+        }), 201
+
+    except IntegrityError as e:
+        db.session.rollback()
+        current_app.logger.error(f"Review post integrity error: {e}")
+        return jsonify({"status": "error", "message": "Database error", "details": str(e.orig)}), 400
+
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Failed to post review: {e}")
+        return jsonify({"status": "error", "message": "Failed to post review", "details": str(e)}), 500
 
 @reviews_bp.route("/rupload_image", methods=["POST"])
 def upload_review_image():

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ from app.routes.upload_image_salon import salon_images_bp
 from app.routes.reviews import reviews_bp
 from app.api.booking.appointments import appointments_bp
 from app.api.payments.methods import payments_bp
+from app.api.payments.receipts import receipts_bp
+from app.api.loyalty.customer_loyaltyp import loyalty_bp
 def create_app():
     print("Starting create_app()")
     app = Flask(__name__)
@@ -64,6 +66,8 @@ def create_app():
         app.register_blueprint(reviews_bp)
         app.register_blueprint(appointments_bp)
         app.register_blueprint(payments_bp)
+        app.register_blueprint(receipts_bp)
+        app.register_blueprint(loyalty_bp)
         print("Adding root route...")
         @app.route('/')
         def home():


### PR DESCRIPTION
Implements three new blueprints to support core app features:

1.  **Loyalty (`/api/loyalty`):** Adds 5 endpoints for customers to view their points dashboard, see program-specific activity, and redeem rewards for promo codes.

2.  **Receipts (`/api/receipts`):** Adds an endpoint for salon owners to retrieve a detailed list of all transactions, including payment status and customer info.

3.  **Reviews (`/reviews_bp`):** Adds the `POST /postreview` endpoint, which allows customers to submit a new review with an optional image upload to S3.