### PR TITLE
Refactor: Separate employee status and type endpoints

### DIFF
--- a/app/api/employee/employee.py
+++ b/app/api/employee/employee.py
@@ -1,0 +1,196 @@
+from flask import Blueprint, jsonify, request
+from app.extensions import db
+# Removed the non-existent Enum import
+from app.models import Employees, EmpAvail 
+from sqlalchemy import select, delete
+from datetime import time, date
+
+employees_bp = Blueprint("employees", __name__, url_prefix="/api/employees")
+
+
+@employees_bp.route("/<int:employee_id>/schedule", methods=["GET"])
+def get_employee_schedule(employee_id):
+    """
+    GET /api/employees/<employee_id>/schedule
+    Purpose: Fetch an employee's schedule, their active status, and their work type.
+    """
+    
+    # Get the employee
+    employee = db.session.get(Employees, employee_id)
+    if not employee:
+        return jsonify({"error": "Employee not found"}), 404
+        
+    stmt = (
+        select(EmpAvail)
+        .where(EmpAvail.employee_id == employee_id)
+        .order_by(EmpAvail.weekday, EmpAvail.effective_from.desc())
+    )
+    schedule_rules = db.session.scalars(stmt).all()
+    
+    schedule_list = [
+        {
+            "id": rule.id,
+            "weekday": rule.weekday,
+            "start_time": rule.start_time.isoformat() if rule.start_time else None,
+            "end_time": rule.end_time.isoformat() if rule.end_time else None,
+            "effective_from": rule.effective_from.isoformat() if rule.effective_from else None,
+            "effective_to": rule.effective_to.isoformat() if rule.effective_to else None,
+        }
+        for rule in schedule_rules
+    ]
+    
+    result = {
+        "employee_id": employee.id,
+        "employment_status": employee.employment_status if employee.employment_status else None, # e.g., "ACTIVE"
+        "employee_type": employee.employee_type if employee.employee_type else None, # e.g., "PART_TIME"
+        "schedule": schedule_list
+    }
+    
+    return jsonify(result), 200
+
+
+@employees_bp.route("/<int:employee_id>/schedule", methods=["PUT"])
+def update_employee_schedule(employee_id):
+    """
+    PUT /api/employees/<employee_id>/schedule
+    Purpose: Update/replace an employee's entire weekly working schedule.
+
+    """
+    
+    # Get the employee
+    employee = db.session.get(Employees, employee_id)
+    if not employee:
+        return jsonify({"error": "Employee not found"}), 404
+
+    data = request.get_json()
+    if not data or "schedule" not in data or not isinstance(data["schedule"], list):
+        return jsonify({"error": "Invalid input. 'schedule' list is required."}), 400
+        
+    new_schedule_data = data["schedule"]
+    today = date.today()
+    new_schedule_rules = []
+
+    try:
+        stmt_delete = delete(EmpAvail).where(EmpAvail.employee_id == employee_id)
+        db.session.execute(stmt_delete)
+
+        for rule_data in new_schedule_data:
+            weekday = rule_data.get("weekday")
+            start_str = rule_data.get("start_time")
+            end_str = rule_data.get("end_time")
+
+            if weekday not in range(0, 7):
+                raise ValueError(f"Invalid weekday: {weekday}")
+
+            if start_str and end_str:
+                new_rule = EmpAvail(
+                    employee_id=employee_id,
+                    weekday=weekday,
+                    start_time=time.fromisoformat(start_str),
+                    end_time=time.fromisoformat(end_str),
+                    effective_from=today
+                )
+                db.session.add(new_rule)
+                new_schedule_rules.append(new_rule)
+        
+        db.session.commit()
+        
+        created_list = [
+            {
+                "id": rule.id,
+                "weekday": rule.weekday,
+                "start_time": rule.start_time.isoformat(),
+                "end_time": rule.end_time.isoformat(),
+                "effective_from": rule.effective_from.isoformat(),
+            }
+            for rule in new_schedule_rules
+        ]
+
+        return jsonify(created_list), 200
+
+    except ValueError as e:
+        db.session.rollback()
+        return jsonify({"error": f"Invalid data format: {str(e)}"}), 400
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": "Database error", "details": str(e)}), 500
+
+
+@employees_bp.route("/<int:employee_id>/status", methods=["PUT"])
+def update_employee_status(employee_id):
+    """
+    PUT /api/employees/<employee_id>/status
+    Purpose: CORRECTED - Edits an employee's active status (e.g., "ACTIVE", "INACTIVE").
+    Input: JSON body with:
+        - employment_status (required): "ACTIVE", "INACTIVE", "ON_LEAVE", etc.
+    """
+    
+    employee = db.session.get(Employees, employee_id)
+    if not employee:
+        return jsonify({"error": "Employee not found"}), 404
+
+    data = request.get_json()
+    new_status_str = data.get("employment_status") 
+
+    if not new_status_str:
+        return jsonify({"error": "employment_status is required"}), 400
+
+    if len(new_status_str) > 15:
+        return jsonify({
+            "error": "Invalid employment_status",
+            "details": f"Must be 15 characters or less (e.g., 'ACTIVE')."
+        }), 400
+        
+    try:
+        employee.employment_status = new_status_str
+        db.session.commit()
+
+        return jsonify({
+            "id": employee.id,
+            "first_name": employee.first_name,
+            "employment_status": employee.employment_status
+        }), 200
+        
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": "Database error", "details": str(e)}), 500
+
+
+@employees_bp.route("/<int:employee_id>/type", methods=["PUT"])
+def update_employee_type(employee_id):
+    """
+    PUT /api/employees/<int:employee_id>/type
+    Purpose: NEW - Edits an employee's work arrangement (e.g., "PART_TIME", "FULL_TIME").
+    Input: JSON body with:
+        - employee_type (required): "PART_TIME", "FULL_TIME", "CONTRACTOR"
+    """
+    
+    employee = db.session.get(Employees, employee_id)
+    if not employee:
+        return jsonify({"error": "Employee not found"}), 404
+
+    data = request.get_json()
+    new_type_str = data.get("employee_type")
+
+    if not new_type_str:
+        return jsonify({"error": "employee_type is required"}), 400
+
+    if len(new_type_str) > 50:
+        return jsonify({
+            "error": "Invalid employee_type",
+            "details": f"Must be 50 characters or less (e.g., 'PART_TIME')."
+        }), 400
+        
+    try:
+        employee.employee_type = new_type_str
+        db.session.commit()
+
+        return jsonify({
+            "id": employee.id,
+            "first_name": employee.first_name,
+            "employee_type": employee.employee_type
+        }), 200
+        
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({"error": "Database error", "details": str(e)}), 500

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+﻿from typing import List, Optional
 
 from sqlalchemy import BigInteger, CHAR, Column, DECIMAL, Date, DateTime, Enum, ForeignKeyConstraint, Index, Integer, JSON, String, TIMESTAMP, Table, Text, Time, VARBINARY, text
 from sqlalchemy.dialects.mysql import TINYINT, VARCHAR
@@ -108,6 +108,9 @@ class Customers(Base):
     last_name = mapped_column(String(100))
     phone_number = mapped_column(String(100))
     address = mapped_column(String(100))
+    gender = mapped_column(String(20))
+    date_of_birth = mapped_column(Date)
+    age = mapped_column(Integer)
 
     user: Mapped['AuthUser'] = relationship('AuthUser', back_populates='customers')
     cart: Mapped[List['Cart']] = relationship('Cart', uselist=True, back_populates='user')
@@ -307,7 +310,7 @@ class CancelPolicy(Base):
 class Employees(Base):
     __tablename__ = 'employees'
     __table_args__ = (
-        ForeignKeyConstraint(['salon_id'], ['salon.id'], ondelete='SET NULL', name='fk_emp_salon'),
+        ForeignKeyConstraint(['salon_id'], ['salon.id'], name='fk_emp_salon'),
         ForeignKeyConstraint(['user_id'], ['auth_user.id'], ondelete='CASCADE', name='fk_employee_auth_user'),
         Index('fk_emp_salon', 'salon_id'),
         Index('user_id_unique', 'user_id', unique=True)
@@ -315,16 +318,17 @@ class Employees(Base):
 
     id = mapped_column(Integer, primary_key=True)
     user_id = mapped_column(Integer, nullable=False)
-    salon_id = mapped_column(Integer, nullable=True)
+    salon_id = mapped_column(Integer, nullable=False)
     created_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
     updated_at = mapped_column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'))
     first_name = mapped_column(String(100))
     last_name = mapped_column(String(100))
     phone_number = mapped_column(String(100))
-    address = mapped_column(String(255))
-    employment_status = mapped_column(String(50))
+    address = mapped_column(String(100))
+    employment_status = mapped_column(String(15))
+    employee_type = mapped_column(String(50))
 
-    salon: Mapped[Optional['Salon']] = relationship('Salon', back_populates='employees')
+    salon: Mapped['Salon'] = relationship('Salon', back_populates='employees')
     user: Mapped['AuthUser'] = relationship('AuthUser', back_populates='employees')
     appointment: Mapped[List['Appointment']] = relationship('Appointment', uselist=True, back_populates='employee')
     emp_avail: Mapped[List['EmpAvail']] = relationship('EmpAvail', uselist=True, back_populates='employee')

--- a/main.py
+++ b/main.py
@@ -31,6 +31,8 @@ from app.api.booking.appointments import appointments_bp
 from app.api.payments.methods import payments_bp
 from app.api.payments.receipts import receipts_bp
 from app.api.loyalty.customer_loyaltyp import loyalty_bp
+
+from app.api.employee.employee import employees_bp
 def create_app():
     print("Starting create_app()")
     app = Flask(__name__)
@@ -68,6 +70,7 @@ def create_app():
         app.register_blueprint(payments_bp)
         app.register_blueprint(receipts_bp)
         app.register_blueprint(loyalty_bp)
+        app.register_blueprint(employees_bp)
         print("Adding root route...")
         @app.route('/')
         def home():


### PR DESCRIPTION
- Corrected the `PUT /employees/<id>/status` route to update the `employment_status` field (e.g., "ACTIVE", "ON_LEAVE").
- Added a new `PUT /employees/<id>/type` route to update the `employee_type` field (e.g., "PART_TIME", "FULL_TIME").
- Updated the `GET /employees/<id>/schedule` route to return both `employment_status` and `employee_type`.